### PR TITLE
Proper scoping for the 'next' stream pointer to prevent crossing the streams because it would be bad.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var decode = function() {
 
   var size = 0
   var header = null
+  var next = null
 
   var flush = function(cb) {
     stdout.end(function() {


### PR DESCRIPTION
Two concurrent streams, each from a separate docker container, can leak data into each other's decoded streams under certain conditions because the `next` variable is global to the module. This update scopes `next` to a single docker stream being decoded to prevent such leaks.

Compulsory GIF reference:
![Don't cross the streams](http://i.giphy.com/Vse57fdw0kkLK.gif)
